### PR TITLE
Added write method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 dist
 *.egg-info
 mercuryapi-*
+Examples/

--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ print(reader.read())
 [b'E2002047381502180820C296', b'0000000000000000C0002403']
 ```
 
+#### reader.write(*epc_target, epc_code*)
+Performs a synchronous write and then returns a boolean indicating the success
+of the operation.
+
+For example:
+```python
+old_epc = 'E2002047381502180820C296'
+new_epc = 'E20020470000000000000012'
+
+reader = Reader('llrp://192.168.0.2')
+reader.set_read_plan([1], "GEN2")
+
+if reader.write(epc_target=old_epc, epc_code=new_epc):
+    print('Rewrited "{}" with "{}"'.format(old_epc, new_epc))
+else:
+    print('Failed writing "{}" with "{}"'.format(old_epc, new_epc))
+```
+
 #### reader.start_reading(*callback*, *on_time=250*, *off_time=0*)
 Starts asynchronous reading. It returns immediately and begins a sequence of
 reads or a continuous read. The results are passed to the *callback*.

--- a/mercury.c
+++ b/mercury.c
@@ -342,8 +342,7 @@ Reader_write(Reader *self, PyObject *args, PyObject *kwds)
     // In case of not target tag found.
     if (ret == TMR_ERROR_NO_TAGS_FOUND)
     {
-        PyErr_SetString(PyExc_RuntimeError, TMR_strerr(&self->reader, ret));
-        return NULL;
+        Py_RETURN_FALSE;
     }
     Py_RETURN_TRUE;
 }

--- a/mercury.c
+++ b/mercury.c
@@ -341,9 +341,7 @@ Reader_write(Reader *self, PyObject *args, PyObject *kwds)
     ret = TMR_writeTag(&self->reader, &filter, &data);
     // In case of not target tag found.
     if (ret == TMR_ERROR_NO_TAGS_FOUND)
-    {
         Py_RETURN_FALSE;
-    }
     Py_RETURN_TRUE;
 }
 

--- a/mercury.c
+++ b/mercury.c
@@ -320,6 +320,35 @@ fail:
 }
 
 static PyObject *
+Reader_write(Reader *self, PyObject *args, PyObject *kwds)
+{
+    char* epc_data;
+    char* epc_target;
+    TMR_Status ret;
+    TMR_TagData data;
+    TMR_TagData target;
+    TMR_TagFilter filter;
+    // Read call arguments.
+    static char *kwlist[] = {"epc_target", "epc_code", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "ss", kwlist, &epc_target, &epc_data))
+        return NULL;
+    // Build data tag to be writen.
+    data.epcByteCount = strlen(epc_data) * sizeof(char) / 2;
+    TMR_hexToBytes(epc_data, data.epc, data.epcByteCount, NULL);
+    // Build filter target tag to be replaced.
+    TMR_TF_init_tag(&filter, &target);
+    // Write data tag on target tag.
+    ret = TMR_writeTag(&self->reader, &filter, &data);
+    // In case of not target tag found.
+    if (ret == TMR_ERROR_NO_TAGS_FOUND)
+    {
+        PyErr_SetString(PyExc_RuntimeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+    Py_RETURN_TRUE;
+}
+
+static PyObject *
 Reader_read(Reader *self, PyObject *args, PyObject *kwds)
 {
     int timeout = 500;
@@ -485,6 +514,9 @@ static PyMethodDef Reader_methods[] = {
     },
     {"set_read_plan", (PyCFunction)Reader_set_read_plan, METH_VARARGS | METH_KEYWORDS,
      "Set the read plan"
+    },
+    {"write", (PyCFunction)Reader_write, METH_VARARGS | METH_KEYWORDS,
+     "Write the epc_target tag with the given epc_code"
     },
     {"read", (PyCFunction)Reader_read, METH_VARARGS | METH_KEYWORDS,
      "Read the tags"


### PR DESCRIPTION
Based on deprecated _TMR_writeTag_, but working on current API version (1.29.4.34)

Receives a target EPC (_epc_target_) for the tag to be written and the new EPC (_epc_code_) to write.

Example of use:

```python
old_epc = '012345678ABCDEF012345678'
new_epc = '0ABCDEF1234567890ABCDEF0'

reader = Reader('llrp://192.168.0.2')
reader.set_read_plan([1], "GEN2")

if reader.write(epc_target=old_epc, epc_code=new_epc):
    print('Rewrited "{}" with "{}"'.format(old_epc, new_epc))
else:
    print('Failed writing "{}" with "{}"'.format(old_epc, new_epc))
```