### PR TITLE
Gen2 Settings Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,150 @@ print(reader.get_model())
 M6e Nano
 ```
 
+#### reader.get_gen2_blf()
+Returns the current Gen2 BLF setting.
+
+For example:
+```python
+print(reader.get_gen2_blf())
+250
+```
+
+#### reader.set_gen2_blf(*blf*)
+Sets the Gen2 BLF. Supported values include:
+ * 250 (250KHz)
+ * 320 (320KHz)
+ * 640 (640KHz)
+
+Not all values may be supported by a particular reader. If successful the
+input value will be returned. For example:
+```python
+print(reader.set_gen2_blf(640))
+640
+```
+
+#### reader.get_gen2_tari()
+Returns the current Gen2 Tari setting.
+
+For example:
+```python
+print(reader.get_gen2_tari())
+0
+```
+
+#### reader.set_gen2_tari(*tari*)
+Sets the Gen2 Tari. Supported values include:
+ * 0 (25 us)
+ * 1 (12.5 us)
+ * 2 (6.25 us)
+
+If successful the input value will be returned. For example:
+```python
+print(reader.set_gen2_tari(1))
+1
+```
+
+#### reader.get_gen2_tagencoding()
+Returns the current Gen2 TagEncoding setting.
+
+For example:
+```python
+print(reader.get_gen2_tagencoding())
+0
+```
+
+#### reader.set_gen2_tagencoding(*tagencoding*)
+Sets the Gen2 TagEncoding. Supported values include:
+ * 0 (FM0)
+ * 1 (M = 2)
+ * 2 (M = 4)
+ * 3 (M = 8)
+
+If successful the input value will be returned. For example:
+```python
+print(reader.set_gen2_tagencoding(2))
+2
+```
+
+#### reader.get_gen2_session()
+Returns the current Gen2 Session setting.
+
+For example:
+```python
+print(reader.get_gen2_session())
+0
+```
+
+#### reader.set_gen2_session(*session*)
+Sets the Gen2 Session. Supported values include:
+ * 0 (S0)
+ * 1 (S1)
+ * 2 (S2)
+ * 3 (S3)
+
+If successful the input value will be returned. For example:
+```python
+print(reader.set_gen2_session(2))
+2
+```
+
+#### reader.get_gen2_target()
+Returns the current Gen2 Target setting.
+
+For example:
+```python
+print(reader.get_gen2_target())
+0
+```
+
+#### reader.set_gen2_target(*target*)
+Sets the Gen2 Target. Supported values include:
+ * 0 (A)
+ * 1 (B)
+ * 2 (AB)
+ * 3 (BA)
+
+If successful the input value will be returned. For example:
+```python
+print(reader.set_gen2_target(2))
+2
+```
+
+#### reader.get_gen2_q()
+Returns the current Gen2 Q setting as a tuple containing the current Q type,
+and initial Q value.
+
+For example:
+```python
+print(reader.get_gen2_q())
+(0, 16)
+```
+
+#### reader.set_gen2_q(*qtype*, *initialq*)
+Sets the Gen2 Q.
+ * *qtype* defines Dynamic vs Static Q value where:
+   * 0 (Dynamic)
+   * 1 (Static)
+ * *initialq* defines 2^*initialq* time slots to be used initially for tag communication.
+
+If Dynamic Q is used then the input *initialq* value is ignored as the reader
+will choose this on its own. It is then likely for *initialq* on a get to be different than the value used on a set.
+
+If successful the input value will be returned. For example:
+```python
+print(reader.set_gen2_q(0, 4))
+(0, 4)
+print(reader.get_gen2_q())
+(0, 64)
+```
+or
+```python
+print(reader.set_gen2_q(1, 4))
+(1, 4)
+print(reader.get_gen2_q())
+(1, 4)
+```
+
 ### TagReadData Object
 Represents a read of an RFID tag:
  * *epc* corresponds to the Electronic Product Code

--- a/mercury.c
+++ b/mercury.c
@@ -882,6 +882,214 @@ Reader_get_model(Reader* self)
     return PyUnicode_FromString(model.value);
 }
 
+static PyObject *
+Reader_get_gen2_blf(Reader* self)
+{
+    TMR_Status ret;
+    TMR_GEN2_LinkFrequency blf_val;
+
+    if ((ret = TMR_paramGet(&self->reader, TMR_PARAM_GEN2_BLF, &blf_val)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    return PyLong_FromLong(blf_val);
+}
+
+static PyObject *
+Reader_set_gen2_blf(Reader* self, PyObject *args)
+{
+    TMR_Status ret;
+    TMR_GEN2_LinkFrequency blf_val;
+
+    if (!PyArg_ParseTuple(args, "i", &blf_val))
+        return NULL;
+
+    if ((ret = TMR_paramSet(&self->reader, TMR_PARAM_GEN2_BLF, &blf_val)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    return PyLong_FromLong(blf_val);
+}
+
+static PyObject *
+Reader_get_gen2_tari(Reader* self)
+{
+    TMR_Status ret;
+    TMR_GEN2_Tari tari_val;
+
+    if ((ret = TMR_paramGet(&self->reader, TMR_PARAM_GEN2_TARI, &tari_val)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    return PyLong_FromLong(tari_val);
+}
+
+static PyObject *
+Reader_set_gen2_tari(Reader* self, PyObject *args)
+{
+    TMR_Status ret;
+    TMR_GEN2_Tari tari_val;
+
+    if (!PyArg_ParseTuple(args, "i", &tari_val))
+        return NULL;
+
+    if ((ret = TMR_paramSet(&self->reader, TMR_PARAM_GEN2_TARI, &tari_val)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    return PyLong_FromLong(tari_val);
+}
+
+static PyObject *
+Reader_get_gen2_tagencoding(Reader* self)
+{
+    TMR_Status ret;
+    TMR_GEN2_TagEncoding tagencoding_val;
+
+    if ((ret = TMR_paramGet(&self->reader, TMR_PARAM_GEN2_TAGENCODING, &tagencoding_val)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    return PyLong_FromLong(tagencoding_val);
+}
+
+static PyObject *
+Reader_set_gen2_tagencoding(Reader* self, PyObject *args)
+{
+    TMR_Status ret;
+    TMR_GEN2_TagEncoding tagencoding_val;
+
+    if (!PyArg_ParseTuple(args, "i", &tagencoding_val))
+        return NULL;
+
+    if ((ret = TMR_paramSet(&self->reader, TMR_PARAM_GEN2_TAGENCODING, &tagencoding_val)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    return PyLong_FromLong(tagencoding_val);
+}
+
+static PyObject *
+Reader_get_gen2_session(Reader* self)
+{
+    TMR_Status ret;
+    TMR_GEN2_Session session_val;
+
+    if ((ret = TMR_paramGet(&self->reader, TMR_PARAM_GEN2_SESSION, &session_val)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    return PyLong_FromLong(session_val);
+}
+
+static PyObject *
+Reader_set_gen2_session(Reader* self, PyObject *args)
+{
+    TMR_Status ret;
+    TMR_GEN2_Session session_val;
+
+    if (!PyArg_ParseTuple(args, "i", &session_val))
+        return NULL;
+
+    if ((ret = TMR_paramSet(&self->reader, TMR_PARAM_GEN2_SESSION, &session_val)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    return PyLong_FromLong(session_val);
+}
+
+static PyObject *
+Reader_get_gen2_target(Reader* self)
+{
+    TMR_Status ret;
+    TMR_GEN2_Target target_val;
+
+    if ((ret = TMR_paramGet(&self->reader, TMR_PARAM_GEN2_TARGET, &target_val)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    return PyLong_FromLong(target_val);
+}
+
+static PyObject *
+Reader_set_gen2_target(Reader* self, PyObject *args)
+{
+    TMR_Status ret;
+    TMR_GEN2_Target target_val;
+
+    if (!PyArg_ParseTuple(args, "i", &target_val))
+        return NULL;
+
+    if ((ret = TMR_paramSet(&self->reader, TMR_PARAM_GEN2_TARGET, &target_val)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    return PyLong_FromLong(target_val);
+}
+
+static PyObject *
+Reader_get_gen2_q(Reader* self)
+{
+    TMR_Status ret;
+    TMR_SR_GEN2_Q model;
+    PyObject *q_value;
+
+    if ((ret = TMR_paramGet(&self->reader, TMR_PARAM_GEN2_Q, &model)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    q_value = PyTuple_New(2);
+    PyTuple_SetItem(q_value, 0, PyLong_FromLong((long) model.type));
+    PyTuple_SetItem(q_value, 1, PyLong_FromLong((long) model.u.staticQ.initialQ));
+
+    return q_value;
+}
+
+static PyObject *
+Reader_set_gen2_q(Reader* self, PyObject *args)
+{
+    TMR_Status ret;
+    TMR_SR_GEN2_Q model;
+    PyObject *q_value;
+
+    if (!PyArg_ParseTuple(args, "ii", &model.type, &model.u.staticQ.initialQ))
+        return NULL;
+
+    if ((ret = TMR_paramSet(&self->reader, TMR_PARAM_GEN2_Q, &model)) != TMR_SUCCESS)
+    {
+        PyErr_SetString(PyExc_TypeError, TMR_strerr(&self->reader, ret));
+        return NULL;
+    }
+
+    q_value = PyTuple_New(2);
+    PyTuple_SetItem(q_value, 0, PyLong_FromLong((long) model.type));
+    PyTuple_SetItem(q_value, 1, PyLong_FromLong((long) model.u.staticQ.initialQ));
+
+    return q_value;
+}
+
 static PyMethodDef Reader_methods[] = {
     {"get_temperature", (PyCFunction)Reader_get_temperature, METH_NOARGS,
      "Returns the chip temperature"
@@ -927,6 +1135,42 @@ static PyMethodDef Reader_methods[] = {
     },
     {"get_model", (PyCFunction)Reader_get_model, METH_NOARGS,
      "Returns the model name"
+    },
+    {"get_gen2_blf", (PyCFunction)Reader_get_gen2_blf, METH_NOARGS,
+     "Returns the current Gen2 BLF setting"
+    },
+    {"set_gen2_blf", (PyCFunction)Reader_set_gen2_blf, METH_VARARGS,
+     "Sets the Gen2 BLF"
+    },
+    {"get_gen2_tari", (PyCFunction)Reader_get_gen2_tari, METH_NOARGS,
+     "Returns the current Gen2 Tari setting"
+    },
+    {"set_gen2_tari", (PyCFunction)Reader_set_gen2_tari, METH_VARARGS,
+     "Sets the Gen2 Tari"
+    },
+    {"get_gen2_tagencoding", (PyCFunction)Reader_get_gen2_tagencoding, METH_NOARGS,
+     "Returns the current Gen2 TagEncoding setting"
+    },
+    {"set_gen2_tagencoding", (PyCFunction)Reader_set_gen2_tagencoding, METH_VARARGS,
+     "Sets the Gen2 TagEncoding"
+    },
+    {"get_gen2_session", (PyCFunction)Reader_get_gen2_session, METH_NOARGS,
+     "Returns the current Gen2 Session setting"
+    },
+    {"set_gen2_session", (PyCFunction)Reader_set_gen2_session, METH_VARARGS,
+     "Sets the Gen2 Session"
+    },
+    {"get_gen2_target", (PyCFunction)Reader_get_gen2_target, METH_NOARGS,
+     "Returns the current Gen2 Target setting"
+    },
+    {"set_gen2_target", (PyCFunction)Reader_set_gen2_target, METH_VARARGS,
+     "Sets the Gen2 Target"
+    },
+    {"get_gen2_q", (PyCFunction)Reader_get_gen2_q, METH_NOARGS,
+     "Returns the current Gen2 Q setting"
+    },
+    {"set_gen2_q", (PyCFunction)Reader_set_gen2_q, METH_VARARGS,
+     "Sets the Gen2 Q"
     },
     {NULL}  /* Sentinel */
 };


### PR DESCRIPTION
Added get and set methods to Reader for handling the Gen2 BLF, Tari, TagEncoding, Session, Target, and Q settings. Values returned and set are generally integers that correlate to the enums defined by the Mercury API within tmr_gen2.h. Method documentation added to the README.md, where setters descriptions detail what the numbers correlate to (e.g. setting 2 = 6.25us for Tari).

Resolves: #7