### PR TITLE
Stop TMR_read() from blocking all python threads.

### DIFF
--- a/mercury.c
+++ b/mercury.c
@@ -723,7 +723,10 @@ Reader_read(Reader *self, PyObject *args, PyObject *kwds)
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|i", kwlist, &timeout))
         return NULL;
 
+    Py_BEGIN_ALLOW_THREADS
     ret = TMR_read(&self->reader, timeout, NULL);
+    Py_END_ALLOW_THREADS
+
     /* In case of TAG ID Buffer Full, extract the tags present in buffer. */
     if (ret != TMR_SUCCESS && ret != TMR_ERROR_TAG_ID_BUFFER_FULL)
     {


### PR DESCRIPTION
Currently when TMR_read() blocks until its timeout is reached it still holds the Python GIL, and so blocks all Python threads not just its own, effectively making this unuseable in multi-threaded programs. Yes there is reader.start_reading() to do async reads which will cooperate with threads, but as mentioned in #39 this does not support memory bank reads.

This small tweak releases the GIL while TMR_read() is running, which is safe as there is no Python related interaction from the C code until it returns, allowing for synchronous reads and memory bank access within a multi-threaded program.

Separate from reads, this same blocking could be happening through other calls like TMR_paramSet, but it's normally fast enough to not be as noticeable as a read with a large timeout. There's still a chance of this causing issues in sensitive programs though, so it may be worthwhile in the future to make some simple wrapper functions to put these thread macros around any TMR calls that actually talk to the reader to ensure they are more thread safe in case of communication delays or timeouts.

For example:
```c
TMR_STATUS TMR_paramSet_threadable(struct TMR_Reader *reader, TMR_Param key, const void *value)
{
    TMR_Status ret;
    Py_BEGIN_ALLOW_THREADS
    ret = TMR_paramSet(reader, key, value);
    Py_END_ALLOW_THREADS
    return ret;
}
```
Which would then be used in place of any current TMR_paramSet() call.