### PR TITLE
this change to mercury.c address following error and warnings:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-APIZIP ?= mercuryapi-AHAB-1.35.2.72-1.zip
-APIVER ?= 1.35.2.72
+APIZIP ?= mercuryapi-BILBO-1.37.2.24.zip
+APIVER ?= 1.37.2.24
+
 PYTHON ?= $(shell { command -v python3 || command -v python; } 2>/dev/null)
 
 .PHONY: all mercuryapi install
@@ -25,4 +26,4 @@ mercuryapi-$(APIVER)/.done: $(APIZIP)
 	touch mercuryapi-$(APIVER)/.done
 
 $(APIZIP):
-	curl https://www.jadaktech.com/wp-content/uploads/2022/08/$(APIZIP) -o $(APIZIP)
+	@echo "you need to download from: https://www.jadaktech.com/documents-downloads/thingmagic-mercury-api-1-37-2/?download (require register step)"

--- a/mercury.c
+++ b/mercury.c
@@ -305,6 +305,11 @@ typedef struct {
     TMR_GEN2_Select_action action;
 } Actions;
 
+enum TMR_GEN2_Select_no_action
+{
+  NO_ACTION = 0xFF
+};
+
 static Actions Reader_actions[] = {
     {"on&off", ON_N_OFF},
     {"on&nop", ON_N_NOP},
@@ -314,7 +319,7 @@ static Actions Reader_actions[] = {
     {"off&nop", OFF_N_NOP},
     {"nop&on", NOP_N_ON},
     {"nop&neg", NOP_N_NEG},
-    {NULL, -1}
+    {NULL, NO_ACTION}
 };
 
 static TMR_GEN2_Select_action str2action(const char *name)
@@ -322,7 +327,7 @@ static TMR_GEN2_Select_action str2action(const char *name)
     Actions *act;
 
     if (name == NULL)
-        return -1;
+        return NO_ACTION;
 
     for(act = Reader_actions; act->name != NULL; act++)
     {
@@ -331,7 +336,7 @@ static TMR_GEN2_Select_action str2action(const char *name)
     }
 
     PyErr_SetString(PyExc_TypeError, "invalid action");
-    return -1;
+    return NO_ACTION;
 }
 
 static int
@@ -439,7 +444,7 @@ parse_gen2filter(TMR_TagFilter *tag_filter, PyObject *arg, TMR_GEN2_Select_actio
         {
             if (obj == Py_None)
                 tag_filter->u.gen2Select.action = defaction;
-            else if ((tag_filter->u.gen2Select.action = str2action(object2str(obj))) == -1)
+            else if ((tag_filter->u.gen2Select.action = str2action(object2str(obj))) == NO_ACTION)
                 return 0;
         }
         else
@@ -986,35 +991,6 @@ Reader_read_tag_mem(Reader *self, PyObject *args, PyObject *kwds)
     free(buf);
 
     return result;
-}
-
-static PyObject *
-Reader_write_tag_mem(Reader *self, PyObject *args, PyObject *kwds)
-{
-    TMR_Status ret;
-    PyObject *epc_target = NULL;
-    uint32_t bank, address;
-    PyObject *data;
-    TMR_TagFilter *tag_filter = NULL;
-
-    static char *kwlist[] = {"bank", "address", "data", "epc_target", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "IIO!|O", kwlist, &bank, &address, &PyByteArray_Type, &data, &epc_target))
-        return NULL;
-
-    if(!parse_multifilter(&tag_filter, epc_target))
-        return NULL;
-
-    ret = TMR_writeTagMemBytes(&self->reader, tag_filter, bank, address, PyByteArray_Size(data), (uint8_t *)PyByteArray_AsString(data));
-    reset_filter(&tag_filter);
-    if (ret == TMR_ERROR_NO_TAGS_FOUND)
-        Py_RETURN_FALSE;
-    else if (ret != TMR_SUCCESS)
-    {
-        PyErr_SetString(PyExc_RuntimeError, TMR_strerr(&self->reader, ret));
-        return NULL;
-    }
-    else
-        Py_RETURN_TRUE;
 }
 
 static PyObject *
@@ -1879,9 +1855,6 @@ static PyMethodDef Reader_methods[] = {
     {"read_tag_mem", (PyCFunction)Reader_read_tag_mem, METH_VARARGS | METH_KEYWORDS,
      "Read bytes from the memory bank of a tag"
     },
-    {"write_tag_mem", (PyCFunction)Reader_write_tag_mem, METH_VARARGS | METH_KEYWORDS,
-     "Write bytes to the memory bank of a tag"
-    },
     {"gpi_get", (PyCFunction)Reader_gpi_get, METH_VARARGS,
      "Gets GPIO pin value"
     },
@@ -2360,8 +2333,9 @@ initmercury(void)
 {
 #endif
     PyObject* m;
+#if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION <= 9)
     PyEval_InitThreads();
-
+#endif
     if (PyType_Ready(&ReaderType) < 0
         || PyType_Ready(&TagDataType) < 0
         || PyType_Ready(&TagReadDataType) < 0


### PR DESCRIPTION
mercury.c: In function ‘parse_gen2filter’:
mercury.c:442:86: warning: comparison of integer expressions of different signedness: ‘TMR_GEN2_Select_action’ and ‘int’ [-Wsign-compare]
  442 |             else if ((tag_filter->u.gen2Select.action = str2action(object2str(obj))) == -1)

mercury.c: In function ‘Reader_write_tag_mem’:
mercury.c:1007:135: error: macro "TMR_writeTagMemBytes" requires 7 arguments, but only 6 given
 1007 |     ret = TMR_writeTagMemBytes(&self->reader, tag_filter, bank, address, PyByteArray_Size(data), (uint8_t *)PyByteArray_AsString(data));

mercury.c: In function ‘PyInit_mercury’:
mercury.c:2363:5: warning: ‘PyEval_InitThreads’ is deprecated [-Wdeprecated-declarations]
 2363 |     PyEval_InitThreads();

TMR_writeTagMemBytes is marked deprecated in the tm_reader.h file from latest api